### PR TITLE
BUGFIX: Add missing ts in request function for alecar6 and mru

### DIFF
--- a/code/algs/alecar6.py
+++ b/code/algs/alecar6.py
@@ -306,7 +306,7 @@ class ALeCaR6:
         return evicted
 
     # Process and access request for the given oblock
-    def request(self, oblock):
+    def request(self, oblock, ts):
         miss = True
         evicted = None
         op = CacheOp.INSERT
@@ -328,7 +328,7 @@ class ALeCaR6:
             evicted = self.miss(oblock)
 
         # Windowed
-        self.visual.addWindow({'hit-rate': 0 if miss else 1}, self.time)
+        self.visual.addWindow({'hit-rate': 0 if miss else 1}, self.time, ts)
 
         # Learning Rate
         if not miss:

--- a/code/algs/mru.py
+++ b/code/algs/mru.py
@@ -53,7 +53,7 @@ class MRU:
 
         return evicted
 
-    def request(self, oblock):
+    def request(self, oblock, ts):
         miss = True
         evicted = None
 
@@ -65,7 +65,7 @@ class MRU:
         else:
             evicted = self.miss(oblock)
 
-        self.visual.addWindow({'hit-rate': 0 if miss else 1}, self.time)
+        self.visual.addWindow({'hit-rate': 0 if miss else 1}, self.time, ts)
 
         if miss:
             self.pollution.incrementUniqueCount()


### PR DESCRIPTION
Fixing break of the code for missing a timestamp parameter in the request function of the Alecar6 and MRU algorithms.
This parameter is only needed for visualization with real-time of the cache hit-rate.
Issue: https://github.com/sylab/cacheus/issues/9